### PR TITLE
Adds Linux build support

### DIFF
--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -129,7 +129,7 @@ void TS808UltraAudioProcessor::prepareToPlay (double sampleRate, int samplesPerB
 
     for (int ch = 0; ch < 2; ++ch)
     {
-        clippingStage[ch].prepare((float)sampleRate * std::powf(2.0f, float(oversampleFactor)));
+        clippingStage[ch].prepare((float)sampleRate * std::pow(2.0f, float(oversampleFactor)));
         clippingStage[ch].setDrive(*driveParameter);
         toneStage[ch].prepare((float)sampleRate);
         toneStage[ch].setTone(*toneParameter);

--- a/Source/dsp/DryComp.cpp
+++ b/Source/dsp/DryComp.cpp
@@ -23,7 +23,7 @@ void DryComp::setThreshold(float val)
     //skew here: 
     // y = 0 to 1
     // y = ((x-min)/(max-min))^factor
-    float skewedValue = std::powf((val - 0.0f) / (10.0f - 0.0f), 2.0f);
+    float skewedValue = std::pow((val - 0.0f) / (10.0f - 0.0f), 2.0f);
 
     auto thesholdInDB = jmap(skewedValue, 0.0f, 1.0f, 0.0f, -80.0f);
     thresholdSmoothed.setTargetValue(thesholdInDB);

--- a/Source/dsp/DryLPF.cpp
+++ b/Source/dsp/DryLPF.cpp
@@ -19,7 +19,7 @@ void DryLPF::setCutoff(float val)
     //skew here: 
     // y = 0 to 1
     // y = ((x-min)/(max-min))^factor
-    float skewedValue = std::powf((val - 0.0f) / (10.0f - 0.0f), 0.1f);
+    float skewedValue = std::pow((val - 0.0f) / (10.0f - 0.0f), 0.1f);
 
     auto cutoffInHz = jmap(skewedValue, 0.0f, 1.0f, 20000.0f, 20.0f);
     cutoffSmoothed.setTargetValue(cutoffInHz);

--- a/TS-808-Ultra.jucer
+++ b/TS-808-Ultra.jucer
@@ -96,6 +96,28 @@
         <MODULEPATH id="chowdsp_dsp" path="modules/chowdsp_utils/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
+    <LINUX_MAKE targetFolder="Builds/LinuxMakefile">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="chowdsp_dsp" path="modules/chowdsp_utils/modules"/>
+        <MODULEPATH id="juce_audio_basics" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_plugin_client" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_audio_utils" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_core" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_data_structures" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_dsp" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_events" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_graphics" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="modules/JUCE/modules"/>
+        <MODULEPATH id="juce_gui_extra" path="modules/JUCE/modules"/>
+      </MODULEPATHS>
+    </LINUX_MAKE>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="chowdsp_dsp" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>


### PR DESCRIPTION
Such a portable open source plugin is surely of interest to Linux users. Since you are using JUCE and Git submodules it was mostly trivial to add build support for Linux.

The only issue is that for hysterical raisins libstdc++ does not support `std::powf`, so I had to change calls to it to `std::pow`. That should be fine, although I am not a huge fan of overloading.

Quite a nice project you have here! I have been soldering together a TS-808 clone and considering getting into WDF:s. At the moment I just needed something to push a JCM 800 amp sim but I might also make use of that Mix knob on bass guitar.